### PR TITLE
#90 [US04] - Sair da Conta

### DIFF
--- a/hortum_mobile/lib/model/user.dart
+++ b/hortum_mobile/lib/model/user.dart
@@ -27,6 +27,17 @@ class User {
         isProductor: json['is_productor']);
   }
 
+  void deleteUser() {
+    deleteSecureData('token_refresh');
+    deleteSecureData('token_access');
+    tokenAccess = null;
+    tokenRefresh = null;
+    email = null;
+    username = null;
+    password = null;
+    isProductor = null;
+  }
+
   Future writeSecureData(String key, String value) async {
     var writeData = await _storage.write(key: key, value: value);
     return writeData;

--- a/hortum_mobile/lib/model/user.dart
+++ b/hortum_mobile/lib/model/user.dart
@@ -30,6 +30,7 @@ class User {
   void deleteUser() {
     deleteSecureData('token_refresh');
     deleteSecureData('token_access');
+    deleteSecureData('email');
     tokenAccess = null;
     tokenRefresh = null;
     email = null;

--- a/hortum_mobile/lib/views/profile/profile.dart
+++ b/hortum_mobile/lib/views/profile/profile.dart
@@ -4,6 +4,9 @@ import 'package:hortum_mobile/globals.dart';
 import 'package:hortum_mobile/views/register/components/form_field.dart';
 import 'package:image_picker/image_picker.dart';
 
+import '../../globals.dart';
+import '../login/login_page.dart';
+
 class UserProfile extends StatefulWidget {
   @override
   _UserProfileState createState() => _UserProfileState();
@@ -174,7 +177,12 @@ class _UserProfileState extends State<UserProfile> {
                               )),
                           MaterialButton(
                             onPressed: () {
-                              print("Sair");
+                              actualUser.deleteUser();
+                              Navigator.pushAndRemoveUntil(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (context) => LoginPage()),
+                                  (route) => route.isCurrent);
                             },
                             child: Text(
                               "Sair",


### PR DESCRIPTION
## Descrição
- Exclusão dos tokens e atributos do usuário logado ao clicar em sair da conta

## Está concertando alguma issue aberta?
- [#90](https://github.com/fga-eps-mds/2020.2-Hortum/issues/90)

## Tarefas gerais realizadas
- Tokens e informações do usuário logado apagadas
- Navigator para a tela de login
