### PR TITLE
#141 Link anúncios HomeCustomerPage

### DIFF
--- a/hortum_mobile/lib/data/announ_data_backend.dart
+++ b/hortum_mobile/lib/data/announ_data_backend.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import 'package:hortum_mobile/globals.dart';
+
+class AnnounDataApi {
+  List<Map> announcements = [];
+
+  Future getAnnoun() async {
+    //Trocar o IPLOCAL pelo ip de sua máquina
+    String userAccessToken = await actualUser.readSecureData('token_access');
+    var url = 'http://$ip:8000/productor/list';
+    var header = {
+      "Content-Type": "application/json",
+      "Authorization": "Bearer " + userAccessToken,
+    };
+
+    var response = await http.get(url, headers: header);
+    List announs = json.decode(response.body);
+    prepareAnnouncement(announs);
+  }
+
+  prepareAnnouncement(List response) {
+    response.forEach((element) {
+      String name = element['user']['username'].toString().split(" ")[0];
+      String profilePic = element['idPicture'];
+      element['announcements'].forEach((element) {
+        Map<String, String> announcement = Map();
+        announcement['name'] = name;
+        announcement['profilePic'] = profilePic;
+        announcement['title'] = element['name'];
+        announcement['price'] =
+            "R\$${element['price'].toStringAsFixed(2).replaceFirst('.', ',')}";
+        announcement['productPicture'] = element['idPicture'];
+        this.announcements.add(announcement);
+      });
+    });
+  }
+}

--- a/hortum_mobile/lib/data/announ_data_backend.dart
+++ b/hortum_mobile/lib/data/announ_data_backend.dart
@@ -25,14 +25,16 @@ class AnnounDataApi {
       String name = element['user']['username'].toString().split(" ")[0];
       String profilePic = element['idPicture'];
       element['announcements'].forEach((element) {
-        Map<String, String> announcement = Map();
-        announcement['name'] = name;
-        announcement['profilePic'] = profilePic;
-        announcement['title'] = element['name'];
-        announcement['price'] =
-            "R\$${element['price'].toStringAsFixed(2).replaceFirst('.', ',')}";
-        announcement['productPicture'] = element['idPicture'];
-        this.announcements.add(announcement);
+        if (element['inventory'] == true) {
+          Map<String, String> announcement = Map();
+          announcement['name'] = name;
+          announcement['profilePic'] = profilePic;
+          announcement['title'] = element['name'];
+          announcement['price'] =
+              "R\$${element['price'].toStringAsFixed(2).replaceFirst('.', ',')}";
+          announcement['productPicture'] = element['idPicture'];
+          this.announcements.add(announcement);
+        }
       });
     });
   }

--- a/hortum_mobile/lib/views/home_customer/components/list_announcements.dart
+++ b/hortum_mobile/lib/views/home_customer/components/list_announcements.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:hortum_mobile/components/announcement_box.dart';
-import 'package:hortum_mobile/components/announcements_data.dart';
+import 'package:hortum_mobile/data/announ_data_backend.dart';
 
 class AnnouncementsList extends StatefulWidget {
   final TextEditingController filter;
+  final AnnounDataApi announData;
 
-  const AnnouncementsList({@required this.filter, Key key}) : super(key: key);
+  const AnnouncementsList(
+      {@required this.filter, @required this.announData, Key key})
+      : super(key: key);
 
   @override
   _AnnouncementsListState createState() => _AnnouncementsListState();
@@ -15,6 +18,7 @@ class _AnnouncementsListState extends State<AnnouncementsList> {
   @override
   Widget build(BuildContext context) {
     Size size = MediaQuery.of(context).size;
+    List announcements = widget.announData.announcements;
     return Container(
       height: size.height * 0.45,
       padding:
@@ -29,12 +33,12 @@ class _AnnouncementsListState extends State<AnnouncementsList> {
               .toLowerCase()
               .contains(widget.filter.text.toLowerCase())) {
             return AnnouncementBox(
-                profilePic: announcements[index]['profilePic'],
+                profilePic: 'assets/images/perfil.jpg',
                 name: announcements[index]['name'],
                 title: announcements[index]['title'],
-                localization: announcements[index]['localization'],
+                localization: 'Asa Norte, 404 Feira Da Tarde',
                 price: announcements[index]['price'],
-                productPic: announcements[index]['productPic']);
+                productPic: 'assets/images/banana.jpg');
           }
           return Container();
         },

--- a/hortum_mobile/lib/views/home_customer/home_customer_page.dart
+++ b/hortum_mobile/lib/views/home_customer/home_customer_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:hortum_mobile/components/footer.dart';
+import 'package:hortum_mobile/data/announ_data_backend.dart';
 import 'package:hortum_mobile/views/home_customer/components/carroussel.dart';
 import 'package:hortum_mobile/views/home_customer/components/list_announcements.dart';
 
@@ -16,34 +18,47 @@ class _CustomerHomePageState extends State<CustomerHomePage> {
   @override
   Widget build(BuildContext context) {
     Size size = MediaQuery.of(context).size;
-    return Scaffold(
-      resizeToAvoidBottomInset: false,
-      body: Stack(children: [
-        SingleChildScrollView(
-          child: Column(
-            children: [
-              Container(
-                  margin: EdgeInsets.only(top: size.height * 0.08),
-                  padding: EdgeInsets.only(left: 10),
-                  height: size.height * 0.25,
-                  child: Carroussel()),
-              Container(
-                  width: size.width * 0.8,
-                  height: size.height * 0.04,
-                  padding: EdgeInsets.only(
-                      left: size.width * 0.02, right: size.width * 0.05),
-                  decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(20),
-                      color: Colors.grey.withOpacity(0.4)),
-                  child: Search(
-                    controller: _filter,
-                  )),
-              AnnouncementsList(filter: _filter)
-            ],
-          ),
-        ),
-        Footer()
-      ]),
+    AnnounDataApi announData = new AnnounDataApi();
+
+    return FutureBuilder(
+      future: announData.getAnnoun(),
+      builder: (BuildContext context, AsyncSnapshot snapshot) {
+        return Scaffold(
+          resizeToAvoidBottomInset: false,
+          body: Stack(children: [
+            SingleChildScrollView(
+              child: Column(
+                children: [
+                  Container(
+                      margin: EdgeInsets.only(top: size.height * 0.08),
+                      padding: EdgeInsets.only(left: 10),
+                      height: size.height * 0.25,
+                      child: Carroussel()),
+                  Container(
+                      width: size.width * 0.8,
+                      height: size.height * 0.04,
+                      padding: EdgeInsets.only(
+                          left: size.width * 0.02, right: size.width * 0.05),
+                      decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(20),
+                          color: Colors.grey.withOpacity(0.4)),
+                      child: Search(
+                        controller: _filter,
+                      )),
+                  snapshot.connectionState == ConnectionState.done
+                      ? AnnouncementsList(
+                          filter: _filter, announData: announData)
+                      : Container(
+                          margin: EdgeInsets.only(top: size.height * 0.25),
+                          child: SpinKitCircle(
+                              color: Color(0xff47CC70).withOpacity(0.7))),
+                ],
+              ),
+            ),
+            Footer()
+          ]),
+        );
+      },
     );
   }
 }

--- a/hortum_mobile/pubspec.yaml
+++ b/hortum_mobile/pubspec.yaml
@@ -27,7 +27,8 @@ dependencies:
   http: ^0.12.2
   splashscreen: ^1.2.0
   flutter_secure_storage: ^4.1.0
-  
+  flutter_spinkit: "^4.1.2"
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.0


### PR DESCRIPTION
## Descrição
Neste pull request foi criado uma classe para armazenar uma lista com todos os anúncios que devem ser mostrados na Home Customer Page

## Está concertando alguma issue aberta?
[#141](https://github.com/fga-eps-mds/2020.2-Hortum/issues/141)

## Tarefas gerais realizadas
Adicione aqui as tarefas realizadas
- Criou-se o método para requisição dos anúncios cadastrados no servidos
- Criou-se método para tratar a informação vinda do Response
- Adicionou-se o Widget FutureBuilder à arvore de Widget na página home_customer para que seja carregada quando a informação estiver disponível
- Utilizou o Flutter Spin Kit para mostrar ao usuário enquanto a requisição é feita e carregada
