### PR TITLE
#95 [US09] - Excluir Anúncio

### DIFF
--- a/hortum_mobile/lib/data/announ_delete_backend.dart
+++ b/hortum_mobile/lib/data/announ_delete_backend.dart
@@ -1,0 +1,18 @@
+import 'dart:convert';
+import 'package:hortum_mobile/globals.dart';
+import 'package:http/http.dart' as http;
+
+class DeleteAnnounApi {
+  static Future deleteAnnoun(String anuncio) async {
+    String userAccessToken = await actualUser.readSecureData('token_access');
+    var url = 'http://$ip:8000/announcement/delete/$anuncio';
+    var header = {
+      "Content-Type": "application/json",
+      "Authorization": "Bearer " + userAccessToken,
+    };
+
+    var response = await http.delete(url, headers: header);
+    Map mapResponse = json.decode(response.body);
+    print(mapResponse.values);
+  }
+}

--- a/hortum_mobile/lib/data/announ_delete_backend.dart
+++ b/hortum_mobile/lib/data/announ_delete_backend.dart
@@ -5,7 +5,7 @@ import 'package:http/http.dart' as http;
 class DeleteAnnounApi {
   static Future deleteAnnoun(String anuncio) async {
     String userAccessToken = await actualUser.readSecureData('token_access');
-    var url = 'http://$ip:8000/announcement/delete/$anuncio';
+    var url = 'http://$ip:8000/announcement/update/$anuncio';
     var header = {
       "Content-Type": "application/json",
       "Authorization": "Bearer " + userAccessToken,

--- a/hortum_mobile/lib/data/announ_delete_backend.dart
+++ b/hortum_mobile/lib/data/announ_delete_backend.dart
@@ -12,7 +12,5 @@ class DeleteAnnounApi {
     };
 
     var response = await http.delete(url, headers: header);
-    Map mapResponse = json.decode(response.body);
-    print(mapResponse.values);
   }
 }

--- a/hortum_mobile/lib/views/home_productor/components/buttons_row.dart
+++ b/hortum_mobile/lib/views/home_productor/components/buttons_row.dart
@@ -1,55 +1,114 @@
 import 'package:flutter/material.dart';
-import 'package:hortum_mobile/views/home_productor/components/dialog_confirm_delete.dart';
+import 'package:hortum_mobile/components/announcements_data.dart';
+import 'package:hortum_mobile/data/announ_delete_backend.dart';
 
-class ButtonsRow extends StatelessWidget {
+class ButtonsRow extends StatefulWidget {
+  final String title;
+
+  const ButtonsRow({@required this.title, Key key}) : super(key: key);
+  @override
+  _ButtonRowState createState() => _ButtonRowState();
+}
+
+class _ButtonRowState extends State<ButtonsRow> {
   @override
   Widget build(BuildContext context) {
     Size size = MediaQuery.of(context).size;
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceAround,
-      children: [
-        Container(
-          height: size.height * 0.03,
-          width: size.width * 0.06,
-          child: MaterialButton(
-            padding: EdgeInsets.all(0),
-            child: Icon(
-              Icons.edit,
-              size: 25,
-              color: Color(0xFF478C5C),
+    return Container(
+      color: Color(0xFFECF87F).withOpacity(0.4),
+      height: size.height * 0.03,
+      width: size.width * 0.26,
+      margin: EdgeInsets.only(left: size.width * 0.55),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          Container(
+            height: size.height * 0.03,
+            width: size.width * 0.06,
+            child: MaterialButton(
+              padding: EdgeInsets.all(0),
+              child: Icon(
+                Icons.edit,
+                size: 25,
+                color: Color(0xFF478C5C),
+              ),
+              onPressed: () {},
             ),
-            onPressed: () {},
           ),
-        ),
-        Container(
-          height: size.height * 0.03,
-          width: size.width * 0.06,
-          child: MaterialButton(
-            padding: EdgeInsets.all(0),
-            child: Icon(
-              Icons.visibility_off,
-              size: 25,
-              color: Color(0xFF478C5C),
+          Container(
+            height: size.height * 0.03,
+            width: size.width * 0.06,
+            child: MaterialButton(
+              padding: EdgeInsets.all(0),
+              child: Icon(
+                Icons.visibility_off,
+                size: 25,
+                color: Color(0xFF478C5C),
+              ),
+              onPressed: () {},
             ),
-            onPressed: () {},
           ),
-        ),
-        Container(
-          height: size.height * 0.03,
-          width: size.width * 0.06,
-          child: MaterialButton(
-            padding: EdgeInsets.all(0),
-            child: Icon(
-              Icons.delete,
-              size: 25,
-              color: Color(0xFF478C5C),
+          Container(
+            height: size.height * 0.03,
+            width: size.width * 0.06,
+            child: MaterialButton(
+              padding: EdgeInsets.all(0),
+              child: Icon(
+                Icons.delete,
+                size: 25,
+                color: Color(0xFF478C5C),
+              ),
+              onPressed: () {
+                showDialog(
+                  context: context,
+                  barrierDismissible: true,
+                  builder: (BuildContext context) {
+                    return AlertDialog(
+                      title: Text('Deseja excluir esse anúncio?'),
+                      content: SingleChildScrollView(
+                        child: ListBody(
+                          children: <Widget>[
+                            Text('Essa ação não pode ser desfeita.'),
+                          ],
+                        ),
+                      ),
+                      actions: <Widget>[
+                        TextButton(
+                          onPressed: () {
+                            DeleteAnnounApi.deleteAnnoun(widget.title);
+                            Navigator.of(context).pop(false);
+                          },
+                          child: Text(
+                            "Sim",
+                            style: TextStyle(
+                              fontFamily: 'Roboto',
+                              fontSize: 19,
+                              color: Color.fromARGB(0xFF, 244, 156, 0),
+                            ),
+                          ),
+                        ),
+                        TextButton(
+                          onPressed: () {
+                            Navigator.of(context).pop(false);
+                          },
+                          child: Text(
+                            "Não",
+                            style: TextStyle(
+                              fontFamily: 'Roboto',
+                              fontSize: 19,
+                              color: Color.fromARGB(0xFF, 244, 156, 0),
+                            ),
+                          ),
+                        ),
+                      ],
+                    );
+                  },
+                );
+              },
             ),
-            onPressed: () {
-              dialogDeleteConfirm(context);
-            },
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/hortum_mobile/lib/views/home_productor/components/buttons_row.dart
+++ b/hortum_mobile/lib/views/home_productor/components/buttons_row.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hortum_mobile/views/home_productor/components/dialog_confirm_delete.dart';
 
 class ButtonsRow extends StatelessWidget {
   @override
@@ -43,7 +44,9 @@ class ButtonsRow extends StatelessWidget {
               size: 25,
               color: Color(0xFF478C5C),
             ),
-            onPressed: () {},
+            onPressed: () {
+              dialogDeleteConfirm(context);
+            },
           ),
         ),
       ],

--- a/hortum_mobile/lib/views/home_productor/components/buttons_row.dart
+++ b/hortum_mobile/lib/views/home_productor/components/buttons_row.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:hortum_mobile/components/announcements_data.dart';
-import 'package:hortum_mobile/data/announ_delete_backend.dart';
+import 'package:hortum_mobile/views/home_productor/components/dialog_confirm_delete.dart';
 
 class ButtonsRow extends StatefulWidget {
   final String title;
@@ -59,51 +58,7 @@ class _ButtonRowState extends State<ButtonsRow> {
                 color: Color(0xFF478C5C),
               ),
               onPressed: () {
-                showDialog(
-                  context: context,
-                  barrierDismissible: true,
-                  builder: (BuildContext context) {
-                    return AlertDialog(
-                      title: Text('Deseja excluir esse anúncio?'),
-                      content: SingleChildScrollView(
-                        child: ListBody(
-                          children: <Widget>[
-                            Text('Essa ação não pode ser desfeita.'),
-                          ],
-                        ),
-                      ),
-                      actions: <Widget>[
-                        TextButton(
-                          onPressed: () {
-                            DeleteAnnounApi.deleteAnnoun(widget.title);
-                            Navigator.of(context).pop(false);
-                          },
-                          child: Text(
-                            "Sim",
-                            style: TextStyle(
-                              fontFamily: 'Roboto',
-                              fontSize: 19,
-                              color: Color.fromARGB(0xFF, 244, 156, 0),
-                            ),
-                          ),
-                        ),
-                        TextButton(
-                          onPressed: () {
-                            Navigator.of(context).pop(false);
-                          },
-                          child: Text(
-                            "Não",
-                            style: TextStyle(
-                              fontFamily: 'Roboto',
-                              fontSize: 19,
-                              color: Color.fromARGB(0xFF, 244, 156, 0),
-                            ),
-                          ),
-                        ),
-                      ],
-                    );
-                  },
-                );
+                dialogDeleteConfirm(context, widget.title);
               },
             ),
           ),

--- a/hortum_mobile/lib/views/home_productor/components/dialog_confirm_delete.dart
+++ b/hortum_mobile/lib/views/home_productor/components/dialog_confirm_delete.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:hortum_mobile/components/announcements_data.dart';
 import 'package:hortum_mobile/data/announ_delete_backend.dart';
 
-void dialogDeleteConfirm(context, index) {
-  showDialog(
+Future<void> dialogDeleteConfirm(context, title) async {
+  return showDialog(
     context: context,
     barrierDismissible: true,
     builder: (BuildContext context) {
@@ -19,7 +18,7 @@ void dialogDeleteConfirm(context, index) {
         actions: <Widget>[
           TextButton(
             onPressed: () {
-              DeleteAnnounApi.deleteAnnoun(announcements[index]['title']);
+              DeleteAnnounApi.deleteAnnoun(title);
               Navigator.of(context).pop(false);
             },
             child: Text(

--- a/hortum_mobile/lib/views/home_productor/components/dialog_confirm_delete.dart
+++ b/hortum_mobile/lib/views/home_productor/components/dialog_confirm_delete.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:hortum_mobile/views/home_productor/home_productor_page.dart';
+import 'package:hortum_mobile/components/announcements_data.dart';
+import 'package:hortum_mobile/data/announ_delete_backend.dart';
 
-void dialogDeleteConfirm(context) {
+void dialogDeleteConfirm(context, index) {
   showDialog(
     context: context,
     barrierDismissible: true,
@@ -18,7 +19,8 @@ void dialogDeleteConfirm(context) {
         actions: <Widget>[
           TextButton(
             onPressed: () {
-              print("Botão Sim");
+              DeleteAnnounApi.deleteAnnoun(announcements[index]['title']);
+              Navigator.of(context).pop(false);
             },
             child: Text(
               "Sim",

--- a/hortum_mobile/lib/views/home_productor/components/dialog_confirm_delete.dart
+++ b/hortum_mobile/lib/views/home_productor/components/dialog_confirm_delete.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:hortum_mobile/views/home_productor/home_productor_page.dart';
+
+void dialogDeleteConfirm(context) {
+  showDialog(
+    context: context,
+    barrierDismissible: true,
+    builder: (BuildContext context) {
+      return AlertDialog(
+        title: Text('Deseja excluir esse anúncio?'),
+        content: SingleChildScrollView(
+          child: ListBody(
+            children: <Widget>[
+              Text('Essa ação não pode ser desfeita.'),
+            ],
+          ),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () {
+              print("Botão Sim");
+            },
+            child: Text(
+              "Sim",
+              style: TextStyle(
+                fontFamily: 'Roboto',
+                fontSize: 19,
+                color: Color.fromARGB(0xFF, 244, 156, 0),
+              ),
+            ),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop(false);
+            },
+            child: Text(
+              "Não",
+              style: TextStyle(
+                fontFamily: 'Roboto',
+                fontSize: 19,
+                color: Color.fromARGB(0xFF, 244, 156, 0),
+              ),
+            ),
+          ),
+        ],
+      );
+    },
+  );
+}

--- a/hortum_mobile/lib/views/home_productor/components/list_announcements.dart
+++ b/hortum_mobile/lib/views/home_productor/components/list_announcements.dart
@@ -12,12 +12,7 @@ class ListAnnouncement extends StatelessWidget {
       scrollDirection: Axis.vertical,
       itemBuilder: (context, index) {
         return Column(children: [
-          Container(
-              color: Color(0xFFECF87F).withOpacity(0.4),
-              height: size.height * 0.03,
-              width: size.width * 0.26,
-              margin: EdgeInsets.only(left: size.width * 0.55),
-              child: ButtonsRow()),
+          ButtonsRow(title: announcements[index]['title']),
           AnnouncementBox(
               profilePic: announcements[index]['profilePic'],
               name: announcements[index]['name'],


### PR DESCRIPTION
## Descrição
- Possibilidade de excluir anúncios

## Está consertando alguma issue aberta?
- [#95](https://github.com/fga-eps-mds/2020.2-Hortum/issues/95)

## Tarefas gerais realizadas
- Refatoração do ButtonRow para passagem do título do anúncio
- Adição do announ_delete_backend.dart  para comunicação com backend
- Adição de dialog para confirmar a exclusão 

## Pull Requests relacionados
[#151](https://github.com/fga-eps-mds/2020.2-Hortum/pull/151)

## Como testar
- 1. Criar um anúncio com um dos seguintes nomes: "Uma dúzia de banana", "Brocolis Fresco" ou "Cenoura Laranja" 
- 2. Ir a HomePage do Produtor e tocar no ícone da lixeira
- 3. Observar no console do servidor se foi excluido ou utilizar o Postman para verificar todos os anúncios registrados
