### PR TITLE
#158 Refatorando rota de listar anúncios

### DIFF
--- a/hortum_mobile/lib/data/announ_data_backend.dart
+++ b/hortum_mobile/lib/data/announ_data_backend.dart
@@ -26,8 +26,7 @@ class AnnounDataApi {
     this.announcements.forEach((element) {
       element['price'] =
           "R\$ ${element['price'].toStringAsFixed(2).replaceFirst('.', ',')}";
-      element['idProductor']['username'] =
-          element['idProductor']['username'].toString().split(" ")[0];
+      element['username'] = element['username'].toString().split(" ")[0];
     });
   }
 }

--- a/hortum_mobile/lib/data/announ_data_backend.dart
+++ b/hortum_mobile/lib/data/announ_data_backend.dart
@@ -4,38 +4,30 @@ import 'package:http/http.dart' as http;
 import 'package:hortum_mobile/globals.dart';
 
 class AnnounDataApi {
-  List<Map> announcements = [];
+  List<dynamic> announcements = [];
 
   Future getAnnoun() async {
     //Trocar o IPLOCAL pelo ip de sua máquina
     String userAccessToken = await actualUser.readSecureData('token_access');
-    var url = 'http://$ip:8000/productor/list';
+    var url = 'http://$ip:8000/announcement/list';
     var header = {
       "Content-Type": "application/json",
       "Authorization": "Bearer " + userAccessToken,
     };
 
     var response = await http.get(url, headers: header);
-    List announs = json.decode(response.body);
-    prepareAnnouncement(announs);
+    this.announcements = json.decode(response.body);
+    print(json.decode(response.body));
+
+    manipulateData();
   }
 
-  prepareAnnouncement(List response) {
-    response.forEach((element) {
-      String name = element['user']['username'].toString().split(" ")[0];
-      String profilePic = element['idPicture'];
-      element['announcements'].forEach((element) {
-        if (element['inventory'] == true) {
-          Map<String, String> announcement = Map();
-          announcement['name'] = name;
-          announcement['profilePic'] = profilePic;
-          announcement['title'] = element['name'];
-          announcement['price'] =
-              "R\$${element['price'].toStringAsFixed(2).replaceFirst('.', ',')}";
-          announcement['productPicture'] = element['idPicture'];
-          this.announcements.add(announcement);
-        }
-      });
+  manipulateData() {
+    this.announcements.forEach((element) {
+      element['price'] =
+          "R\$ ${element['price'].toStringAsFixed(2).replaceFirst('.', ',')}";
+      element['idProductor']['username'] =
+          element['idProductor']['username'].toString().split(" ")[0];
     });
   }
 }

--- a/hortum_mobile/lib/views/home_customer/components/list_announcements.dart
+++ b/hortum_mobile/lib/views/home_customer/components/list_announcements.dart
@@ -34,7 +34,7 @@ class _AnnouncementsListState extends State<AnnouncementsList> {
               .contains(widget.filter.text.toLowerCase())) {
             return AnnouncementBox(
                 profilePic: 'assets/images/perfil.jpg',
-                name: announcements[index]['idProductor']['username'],
+                name: announcements[index]['username'],
                 title: announcements[index]['name'],
                 localization: 'Asa Norte, 404 Feira Da Tarde',
                 price: announcements[index]['price'],

--- a/hortum_mobile/lib/views/home_customer/components/list_announcements.dart
+++ b/hortum_mobile/lib/views/home_customer/components/list_announcements.dart
@@ -34,8 +34,8 @@ class _AnnouncementsListState extends State<AnnouncementsList> {
               .contains(widget.filter.text.toLowerCase())) {
             return AnnouncementBox(
                 profilePic: 'assets/images/perfil.jpg',
-                name: announcements[index]['name'],
-                title: announcements[index]['title'],
+                name: announcements[index]['idProductor']['username'],
+                title: announcements[index]['name'],
                 localization: 'Asa Norte, 404 Feira Da Tarde',
                 price: announcements[index]['price'],
                 productPic: 'assets/images/banana.jpg');

--- a/hortum_mobile/test/announ_data_backend_test.dart
+++ b/hortum_mobile/test/announ_data_backend_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hortum_mobile/data/announ_data_backend.dart';
+
+main() {
+  test('Given a list of announcements manipulate correctly the data', () {
+    AnnounDataApi annouData = new AnnounDataApi();
+    dynamic element = {
+      "idProductor": {"username": "Usuário Teste", "idPicture": null},
+      "name": "Anúncio Teste",
+      "type_of_product": "Banana",
+      "description": "Descrição teste",
+      "price": 15.0,
+      "idPicture": null
+    };
+
+    annouData.announcements.add(element);
+
+    annouData.manipulateData();
+    dynamic result = {
+      "idProductor": {"username": "Usuário", "idPicture": null},
+      "name": "Anúncio Teste",
+      "type_of_product": "Banana",
+      "description": "Descrição teste",
+      "price": "R\$ 15,00",
+      "idPicture": null
+    };
+    expect(result, annouData.announcements[0]);
+  });
+}

--- a/hortum_mobile/test/announ_data_backend_test.dart
+++ b/hortum_mobile/test/announ_data_backend_test.dart
@@ -5,7 +5,8 @@ main() {
   test('Given a list of announcements manipulate correctly the data', () {
     AnnounDataApi annouData = new AnnounDataApi();
     dynamic element = {
-      "idProductor": {"username": "Usuário Teste", "idPicture": null},
+      "username": "Usuário Teste",
+      "idPictureProductor": null,
       "name": "Anúncio Teste",
       "type_of_product": "Banana",
       "description": "Descrição teste",
@@ -17,7 +18,8 @@ main() {
 
     annouData.manipulateData();
     dynamic result = {
-      "idProductor": {"username": "Usuário", "idPicture": null},
+      "username": "Usuário",
+      "idPictureProductor": null,
       "name": "Anúncio Teste",
       "type_of_product": "Banana",
       "description": "Descrição teste",


### PR DESCRIPTION
## Descrição
Devido à alteração da rota de listar os anúncios no servidor, foi trocado a rota e as regras de negócio, uma vez que os dados passaram a chegar como o mobile precisava.

## Está concertando alguma issue aberta?
[#158](https://github.com/fga-eps-mds/2020.2-Hortum/issues/158)

## Tarefas gerais realizadas
- Mudança da rota de listar anúncios para : /announcements/list
- Atualização do acesso aos atributos da lista
- Teste do método manipulateData() que é responsável por manipular alguns dados da lista, como o preço que é um float no banco mas deve ser apresentado como "R$ 15,00" para o usuário, por exemplo
