### PR TITLE
#97 [US10/11] - Procurar Produto

### DIFF
--- a/hortum_mobile/lib/data/announ_data_backend.dart
+++ b/hortum_mobile/lib/data/announ_data_backend.dart
@@ -21,7 +21,6 @@ class AnnounDataApi {
     };
 
     var response = await http.get(url, headers: header);
-    this.announcements = [];
     this.announcements = json.decode(response.body);
 
     manipulateData();

--- a/hortum_mobile/lib/data/announ_data_backend.dart
+++ b/hortum_mobile/lib/data/announ_data_backend.dart
@@ -6,18 +6,23 @@ import 'package:hortum_mobile/globals.dart';
 class AnnounDataApi {
   List<dynamic> announcements = [];
 
-  Future getAnnoun() async {
+  Future getAnnoun(String filter) async {
     //Trocar o IPLOCAL pelo ip de sua máquina
     String userAccessToken = await actualUser.readSecureData('token_access');
-    var url = 'http://$ip:8000/announcement/list';
+    String url;
+    if (filter.isEmpty)
+      url = 'http://$ip:8000/announcement/list';
+    else
+      url = 'http://$ip:8000/announcement/list/${filter}';
+
     var header = {
       "Content-Type": "application/json",
       "Authorization": "Bearer " + userAccessToken,
     };
 
     var response = await http.get(url, headers: header);
+    this.announcements = [];
     this.announcements = json.decode(response.body);
-    print(json.decode(response.body));
 
     manipulateData();
   }

--- a/hortum_mobile/lib/views/home_customer/components/home_type.dart
+++ b/hortum_mobile/lib/views/home_customer/components/home_type.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+class HomeType extends StatefulWidget {
+  final bool isAnnouncements;
+  final onPressed;
+
+  const HomeType(
+      {@required this.isAnnouncements, @required this.onPressed, Key key})
+      : super(key: key);
+  @override
+  _HomeTypeState createState() => _HomeTypeState();
+}
+
+class _HomeTypeState extends State<HomeType> {
+  @override
+  Widget build(BuildContext context) {
+    Size size = MediaQuery.of(context).size;
+    return Container(
+      height: size.height * 0.1,
+      child: Padding(
+        padding: EdgeInsets.only(left: size.width * 0.12),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              child: Align(
+                  alignment: Alignment.center,
+                  child: Text(
+                      widget.isAnnouncements ? 'Anúncios' : 'Produtores',
+                      style: TextStyle(
+                          fontFamily: 'Comfortaa-Bold',
+                          fontWeight: FontWeight.bold,
+                          fontSize: size.height * 0.022))),
+              margin: EdgeInsets.only(top: size.height * 0.05),
+              width: size.width * 0.5,
+              height: size.height * 0.04,
+              decoration: BoxDecoration(
+                  color: Color(0xffA7DDB7),
+                  borderRadius: BorderRadius.all(Radius.circular(15))),
+            ),
+            Container(
+              margin: EdgeInsets.only(top: 35),
+              child: IconButton(
+                  icon: Icon(Icons.cached, color: Color(0xff72C98C)),
+                  onPressed: widget.onPressed,
+                  alignment: Alignment.center),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/hortum_mobile/lib/views/home_customer/components/list_announcements.dart
+++ b/hortum_mobile/lib/views/home_customer/components/list_announcements.dart
@@ -20,29 +20,31 @@ class _AnnouncementsListState extends State<AnnouncementsList> {
     Size size = MediaQuery.of(context).size;
     List announcements = widget.announData.announcements;
     return Container(
-      height: size.height * 0.45,
-      padding:
-          EdgeInsets.only(right: size.width * 0.05, left: size.width * 0.05),
-      margin: EdgeInsets.only(top: size.height * 0.06),
-      child: ListView.builder(
-        itemCount: announcements.length,
-        scrollDirection: Axis.vertical,
-        itemBuilder: (context, index) {
-          if (announcements[index]['title']
-              .toString()
-              .toLowerCase()
-              .contains(widget.filter.text.toLowerCase())) {
-            return AnnouncementBox(
-                profilePic: 'assets/images/perfil.jpg',
-                name: announcements[index]['username'],
-                title: announcements[index]['name'],
-                localization: 'Asa Norte, 404 Feira Da Tarde',
-                price: announcements[index]['price'],
-                productPic: 'assets/images/banana.jpg');
-          }
-          return Container();
-        },
-      ),
-    );
+        height: size.height * 0.43,
+        padding:
+            EdgeInsets.only(right: size.width * 0.05, left: size.width * 0.05),
+        child: announcements.length != 0
+            ? ListView.builder(
+                itemCount: announcements.length,
+                scrollDirection: Axis.vertical,
+                itemBuilder: (context, index) {
+                  return AnnouncementBox(
+                      profilePic: 'assets/images/perfil.jpg',
+                      name: announcements[index]['username'],
+                      title: announcements[index]['name'],
+                      localization: 'Asa Norte, 404 Feira Da Tarde',
+                      price: announcements[index]['price'],
+                      productPic: 'assets/images/banana.jpg');
+                },
+              )
+            : Container(
+                margin: EdgeInsets.only(top: size.height * 0.15),
+                width: size.width * 0.6,
+                child: Text(
+                  "Infelizmente!!\nNão encontramos nenhum resultado para a sua busca",
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: Color(0xff1D8E40), fontSize: 15),
+                ),
+              ));
   }
 }

--- a/hortum_mobile/lib/views/home_customer/components/search.dart
+++ b/hortum_mobile/lib/views/home_customer/components/search.dart
@@ -13,7 +13,7 @@ class _SearchState extends State<Search> {
     Size size = MediaQuery.of(context).size;
     return TextFormField(
       decoration: InputDecoration(
-          prefixIcon: Icon(Icons.search),
+          prefixIcon: Icon(Icons.search, color: Color(0xff59981A)),
           hintText: "Pesquisar",
           border: InputBorder.none,
           contentPadding: EdgeInsets.only(bottom: size.height * 0.018)),

--- a/hortum_mobile/lib/views/home_customer/home_customer_page.dart
+++ b/hortum_mobile/lib/views/home_customer/home_customer_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:hortum_mobile/components/footer.dart';
 import 'package:hortum_mobile/data/announ_data_backend.dart';
 import 'package:hortum_mobile/views/home_customer/components/carroussel.dart';
+import 'package:hortum_mobile/views/home_customer/components/home_type.dart';
 import 'package:hortum_mobile/views/home_customer/components/list_announcements.dart';
 
 import 'components/search.dart';
@@ -14,6 +15,7 @@ class CustomerHomePage extends StatefulWidget {
 
 class _CustomerHomePageState extends State<CustomerHomePage> {
   final TextEditingController _filter = TextEditingController();
+  bool isAnnouncements = true;
 
   @override
   Widget build(BuildContext context) {
@@ -21,7 +23,7 @@ class _CustomerHomePageState extends State<CustomerHomePage> {
     AnnounDataApi announData = new AnnounDataApi();
 
     return FutureBuilder(
-      future: announData.getAnnoun(),
+      future: announData.getAnnoun(_filter.text),
       builder: (BuildContext context, AsyncSnapshot snapshot) {
         return Scaffold(
           resizeToAvoidBottomInset: false,
@@ -42,13 +44,23 @@ class _CustomerHomePageState extends State<CustomerHomePage> {
                           left: size.width * 0.02, right: size.width * 0.05),
                       decoration: BoxDecoration(
                           borderRadius: BorderRadius.circular(20),
-                          color: Colors.grey.withOpacity(0.4)),
+                          border: Border.all(color: Color(0xff59981A)),
+                          color: Colors.transparent),
                       child: Search(
                         controller: _filter,
                       )),
+                  HomeType(
+                    isAnnouncements: isAnnouncements,
+                    onPressed: () {
+                      this.isAnnouncements = !this.isAnnouncements;
+                      setState(() {});
+                    },
+                  ),
                   snapshot.connectionState == ConnectionState.done
-                      ? AnnouncementsList(
-                          filter: _filter, announData: announData)
+                      ? this.isAnnouncements
+                          ? AnnouncementsList(
+                              filter: _filter, announData: announData)
+                          : Container()
                       : Container(
                           margin: EdgeInsets.only(top: size.height * 0.25),
                           child: SpinKitCircle(


### PR DESCRIPTION
## Descrição
- Nessa User Story foi implementado a possibilidade do consumidor procurar por algum anúncio/produto. Para isto foi necessário uma refatoração no protótipo, alterando um pouco o visual da tela principal do consumidor.

## Está concertando alguma issue aberta?
- [#96](https://github.com/fga-eps-mds/2020.2-Hortum/issues/96)
- [#97](https://github.com/fga-eps-mds/2020.2-Hortum/issues/97)

## Pull Requests relacionados
- [#172](https://github.com/fga-eps-mds/2020.2-Hortum/pull/172)

## Tarefas gerais realizadas
Adicione aqui as tarefas realizadas
- Alteração no Protótipo de Alta Fidelidade - Tela Principal Consumidor
- Desenvolvimento do novo estilo visual
- Agora ao fazer uma pesquisa a resposta é dada através de uma requisição no front
- Adição de uma mensagem em ocasiões que não tem resultado para as buscas

## Testes
- Primeiramente visualize o protótipo de alta fidelidade para validar também o que foi alterado.
- Utilize o código presente na branch "feature/97-procurar-anuncio" no servidor para que esteja disponível a rota que está sendo utilizada no mobile ( caso ainda não tenha sido aprovada para a main )
