### PR TITLE
#38 Altreação da rota incorreta

### DIFF
--- a/hortum_mobile/lib/data/prod_log_data_backend.dart
+++ b/hortum_mobile/lib/data/prod_log_data_backend.dart
@@ -16,7 +16,7 @@ class ProdLoggedAnnounDataApi {
 
   Future getAnnounProd() async {
     String encodedEmail = encodeString(actualUser.email);
-    String url = 'http://$ip:8000/productor/retrieve/${encodedEmail}';
+    String url = 'http://$ip:8000/announcement/retrieve/${encodedEmail}';
 
     var header = {
       "Content-Type": "application/json",
@@ -26,7 +26,7 @@ class ProdLoggedAnnounDataApi {
     Response response =
         await this.dio.get(url, options: Options(headers: header));
 
-    this.announcements = response.data['announcements'];
+    this.announcements = response.data;
     manipulateData();
   }
 

--- a/hortum_mobile/test/home_productor_page_test.dart
+++ b/hortum_mobile/test/home_productor_page_test.dart
@@ -12,22 +12,19 @@ main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   final dioMock = DioMock();
 
-  dynamic response = {
-    "username": "Usuário Teste",
-    "email": "usuário@gmail.com",
-    "idPicture": null,
-    "announcements": [
-      {
-        "username": "Usuário Teste",
-        "idPictureProductor": null,
-        "name": "Folha Verde",
-        "type_of_product": "Alface",
-        "description": "Alface plantado na fazenda",
-        "price": 5.0,
-        "idPicture": null
-      }
-    ]
-  };
+  List<dynamic> response = [
+    {
+      "email": "usuário@gmail.com",
+      "username": "Usuário Teste",
+      "idPictureProductor": null,
+      "name": "Folha Verde",
+      "type_of_product": "Alface",
+      "description": "Alface plantado na fazenda",
+      "price": 5.0,
+      "idPicture": null,
+      "likes": 0
+    },
+  ];
 
   Widget makeTestable() {
     return MaterialApp(


### PR DESCRIPTION
## Descrição
- Corrigido bug devido a rota incorreta para homepage do produtor

## Está concertando alguma issue aberta?
- #38

## Tarefas gerais realizadas
- Alteração da rota `productor/retrieve` para `announcement/retrieve` 
- Alterado a forma como os anúncios são recibidos retirando o `[announcements]` da response.data
