### PR TITLE
#204 Correção Tela Detalhes do Produtor

### DIFF
--- a/hortum_mobile/lib/components/announcement_box.dart
+++ b/hortum_mobile/lib/components/announcement_box.dart
@@ -59,7 +59,8 @@ class _AnnouncementBoxState extends State<AnnouncementBox> {
               key: Key('productorDetailsButton'),
               onPressed: () {
                 Navigator.push(context, MaterialPageRoute(builder: (context) {
-                  return ProductorDetails(email: encodeString(widget.email));
+                  return ProductorDetails(
+                      email: encodeString(widget.email), name: widget.name);
                 }));
               },
               child: Column(

--- a/hortum_mobile/lib/components/productors_box.dart
+++ b/hortum_mobile/lib/components/productors_box.dart
@@ -38,7 +38,10 @@ class _ProductorsBoxState extends State<ProductorsBox> {
       child: MaterialButton(
         onPressed: () {
           Navigator.push(context, MaterialPageRoute(builder: (context) {
-            return ProductorDetails(email: encodeString(widget.email));
+            return ProductorDetails(
+              email: encodeString(widget.email),
+              name: widget.name,
+            );
           }));
         },
         child: Row(

--- a/hortum_mobile/lib/views/announcement_details/announcement_details_page.dart
+++ b/hortum_mobile/lib/views/announcement_details/announcement_details_page.dart
@@ -167,7 +167,8 @@ class _AnnouncementDetailsState extends State<AnnouncementDetails> {
                       Navigator.push(context,
                           MaterialPageRoute(builder: (context) {
                         return ProductorDetails(
-                            email: encodeString(widget.email));
+                            email: encodeString(widget.email),
+                            name: widget.name);
                       }));
                     },
                   ),

--- a/hortum_mobile/lib/views/productor_details/components/announcements_details.dart
+++ b/hortum_mobile/lib/views/productor_details/components/announcements_details.dart
@@ -27,7 +27,7 @@ class _AnnouncementsDetailsState extends State<AnnouncementsDetails> {
                 ProductorLocalization(),
                 AnnouncementTag(),
                 ProductorDetaislService.completeAnnouncements(
-                    widget.prodData.announcements)
+                    widget.prodData.announcements, size)
               ],
             ),
           ],

--- a/hortum_mobile/lib/views/productor_details/components/announcements_details.dart
+++ b/hortum_mobile/lib/views/productor_details/components/announcements_details.dart
@@ -19,7 +19,7 @@ class _AnnouncementsDetailsState extends State<AnnouncementsDetails> {
     Size size = MediaQuery.of(context).size;
     return Container(
         width: size.width,
-        height: size.height * 0.45,
+        height: size.height * 0.47,
         child: ListView(
           children: [
             Column(

--- a/hortum_mobile/lib/views/productor_details/components/name_actions.dart
+++ b/hortum_mobile/lib/views/productor_details/components/name_actions.dart
@@ -17,12 +17,12 @@ class _NameActionsWidgetState extends State<NameActionsWidget> {
   Widget build(BuildContext context) {
     Size size = MediaQuery.of(context).size;
     return Padding(
-      padding: EdgeInsets.only(left: size.width * 0.25),
+      padding: EdgeInsets.only(left: size.width * 0.15),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Container(
-            width: size.width * 0.45,
+            width: size.width * 0.7,
             child: Text(
               widget.name,
               style: TextStyle(
@@ -32,10 +32,6 @@ class _NameActionsWidgetState extends State<NameActionsWidget> {
               textAlign: TextAlign.center,
             ),
           ),
-          IconButton(
-              padding: EdgeInsets.only(left: 10),
-              icon: Icon(Icons.ios_share, color: Color(0xffA7DDB7)),
-              onPressed: () {}),
           IconButton(
               padding: EdgeInsets.only(top: 5, right: 10),
               icon: Icon(Icons.report, color: Color(0xffFF4D00)),

--- a/hortum_mobile/lib/views/productor_details/components/name_actions.dart
+++ b/hortum_mobile/lib/views/productor_details/components/name_actions.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hortum_mobile/views/complaint/complaint_page.dart';
+import 'package:hortum_mobile/views/productor_details/services/productor_details_services.dart';
 
 class NameActionsWidget extends StatefulWidget {
   final String name;
@@ -16,6 +17,7 @@ class _NameActionsWidgetState extends State<NameActionsWidget> {
   @override
   Widget build(BuildContext context) {
     Size size = MediaQuery.of(context).size;
+    String name = ProductorDetaislService.formatName(widget.name);
     return Padding(
       padding: EdgeInsets.only(left: size.width * 0.15),
       child: Row(
@@ -24,7 +26,7 @@ class _NameActionsWidgetState extends State<NameActionsWidget> {
           Container(
             width: size.width * 0.7,
             child: Text(
-              widget.name,
+              name,
               style: TextStyle(
                   fontFamily: 'Roboto-Bold',
                   fontWeight: FontWeight.bold,

--- a/hortum_mobile/lib/views/productor_details/components/name_actions.dart
+++ b/hortum_mobile/lib/views/productor_details/components/name_actions.dart
@@ -21,11 +21,17 @@ class _NameActionsWidgetState extends State<NameActionsWidget> {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Text(widget.name,
+          Container(
+            width: size.width * 0.45,
+            child: Text(
+              widget.name,
               style: TextStyle(
                   fontFamily: 'Roboto-Bold',
                   fontWeight: FontWeight.bold,
-                  fontSize: 25)),
+                  fontSize: 25),
+              textAlign: TextAlign.center,
+            ),
+          ),
           IconButton(
               padding: EdgeInsets.only(left: 10),
               icon: Icon(Icons.ios_share, color: Color(0xffA7DDB7)),

--- a/hortum_mobile/lib/views/productor_details/productor_details_page.dart
+++ b/hortum_mobile/lib/views/productor_details/productor_details_page.dart
@@ -10,9 +10,11 @@ import 'package:hortum_mobile/views/productor_details/components/name_actions.da
 
 class ProductorDetails extends StatefulWidget {
   final String email;
+  final String name;
   final Dio dio;
 
-  const ProductorDetails({@required this.email, this.dio, Key key})
+  const ProductorDetails(
+      {@required this.email, @required this.name, this.dio, Key key})
       : super(key: key);
 
   @override
@@ -49,7 +51,7 @@ class _ProductorDetailsState extends State<ProductorDetails> {
                                 bottomMargin: size.height * 0.02,
                               ),
                               NameActionsWidget(
-                                name: prodData.announcements[0]['username'],
+                                name: widget.name,
                                 email: widget.email,
                               ),
                               AnnouncementsDetails(prodData: prodData)

--- a/hortum_mobile/lib/views/productor_details/services/productor_details_services.dart
+++ b/hortum_mobile/lib/views/productor_details/services/productor_details_services.dart
@@ -10,6 +10,7 @@ class ProductorDetaislService {
               .map<Widget>((dynamic announcement) => AnnouncementBox(
                   profilePic: 'assets/images/perfil.jpg',
                   email: announcement['email'],
+                  description: announcement['description'],
                   name: announcement['username'].toString().split(' ')[0],
                   title: announcement['name'],
                   localization: 'Asa Norte Feira 404',

--- a/hortum_mobile/lib/views/productor_details/services/productor_details_services.dart
+++ b/hortum_mobile/lib/views/productor_details/services/productor_details_services.dart
@@ -2,19 +2,29 @@ import 'package:flutter/material.dart';
 import 'package:hortum_mobile/components/announcement_box.dart';
 
 class ProductorDetaislService {
-  static Widget completeAnnouncements(List<dynamic> announcements) {
-    return Column(
-        key: Key('columnAnnoun'),
-        children: announcements
-            .map<Widget>((dynamic announcement) => AnnouncementBox(
-                profilePic: 'assets/images/perfil.jpg',
-                email: announcement['email'],
-                name: announcement['username'].toString().split(' ')[0],
-                title: announcement['name'],
-                localization: 'Asa Norte Feira 404',
-                price:
-                    "R\$ ${announcement['price'].toStringAsFixed(2).replaceFirst('.', ',')}",
-                productPic: 'assets/images/banana.jpg'))
-            .toList());
+  static Widget completeAnnouncements(List<dynamic> announcements, Size size) {
+    if (announcements.length != 0) {
+      return Column(
+          key: Key('columnAnnoun'),
+          children: announcements
+              .map<Widget>((dynamic announcement) => AnnouncementBox(
+                  profilePic: 'assets/images/perfil.jpg',
+                  email: announcement['email'],
+                  name: announcement['username'].toString().split(' ')[0],
+                  title: announcement['name'],
+                  localization: 'Asa Norte Feira 404',
+                  price:
+                      "R\$ ${announcement['price'].toStringAsFixed(2).replaceFirst('.', ',')}",
+                  productPic: 'assets/images/banana.jpg'))
+              .toList());
+    }
+    return Container(
+      width: size.width * 0.65,
+      child: Text(
+        "Este produtor não possui anúncios disponíveis no momento !!",
+        textAlign: TextAlign.center,
+        style: TextStyle(color: Color(0xff1D8E40)),
+      ),
+    );
   }
 }

--- a/hortum_mobile/lib/views/productor_details/services/productor_details_services.dart
+++ b/hortum_mobile/lib/views/productor_details/services/productor_details_services.dart
@@ -28,4 +28,11 @@ class ProductorDetaislService {
       ),
     );
   }
+
+  static String formatName(String name) {
+    if (name.length > 25) {
+      return name.split(' ')[0] + ' ' + name.split(' ')[1];
+    } else
+      return name;
+  }
 }

--- a/hortum_mobile/test/views/productor_details/productor_details_page_test.dart
+++ b/hortum_mobile/test/views/productor_details/productor_details_page_test.dart
@@ -27,11 +27,12 @@ main() {
 
   Widget makeTestable() {
     return MaterialApp(
-      home: ProductorDetails(email: "emailteste@gmail.com", dio: dioMock),
+      home: ProductorDetails(
+          email: "emailteste@gmail.com", name: "Produtor", dio: dioMock),
     );
   }
 
-  testWidgets('Testing if RegisterAnnouncementPage renders correctly',
+  testWidgets('Testing if ProductorDetailsPage renders correctly',
       (WidgetTester tester) async {
     actualUser.isProductor = false;
     actualUser.tokenAccess = 'token';

--- a/hortum_mobile/test/views/productor_details/services/productor_details_service_test.dart
+++ b/hortum_mobile/test/views/productor_details/services/productor_details_service_test.dart
@@ -16,12 +16,26 @@ main() {
       "likes": 0
     }
   ];
-  testWidgets('Testing the ProductorDetailsService',
+  testWidgets(
+      'Testing the ProductorDetailsService when the productor has announcements',
       (WidgetTester tester) async {
     Widget result = ProductorDetaislService.completeAnnouncements(
         param, Size(360.0, 692.0));
     Widget pump = MaterialApp(home: result);
     await tester.pumpWidget(pump);
     expect(find.byKey(Key('columnAnnoun')), findsOneWidget);
+  });
+
+  testWidgets(
+      "Testing the ProductorDetailsService when the productor hasn't announcements",
+      (WidgetTester tester) async {
+    Widget result =
+        ProductorDetaislService.completeAnnouncements([], Size(360.0, 692.0));
+    Widget pump = MaterialApp(home: result);
+    await tester.pumpWidget(pump);
+    expect(
+        find.text(
+            'Este produtor não possui anúncios disponíveis no momento !!'),
+        findsOneWidget);
   });
 }

--- a/hortum_mobile/test/views/productor_details/services/productor_details_service_test.dart
+++ b/hortum_mobile/test/views/productor_details/services/productor_details_service_test.dart
@@ -18,7 +18,8 @@ main() {
   ];
   testWidgets('Testing the ProductorDetailsService',
       (WidgetTester tester) async {
-    Widget result = ProductorDetaislService.completeAnnouncements(param);
+    Widget result = ProductorDetaislService.completeAnnouncements(
+        param, Size(360.0, 692.0));
     Widget pump = MaterialApp(home: result);
     await tester.pumpWidget(pump);
     expect(find.byKey(Key('columnAnnoun')), findsOneWidget);

--- a/hortum_mobile/test/views/productor_details/services/productor_details_service_test.dart
+++ b/hortum_mobile/test/views/productor_details/services/productor_details_service_test.dart
@@ -34,8 +34,7 @@ main() {
     Widget pump = MaterialApp(home: result);
     await tester.pumpWidget(pump);
     expect(
-        find.text(
-            'Este produtor não possui anúncios disponíveis no momento !!'),
+        find.text('Este produtor não possui anúncios disponíveis no momento !'),
         findsOneWidget);
   });
 }


### PR DESCRIPTION
## Descrição
Nesta issue foi corrigido o overflow do nome e também o erro quando o produtor não possuía nenhum anúncio cadastrado

## Está concertando alguma issue aberta?
[#204](https://github.com/fga-eps-mds/2020.2-Hortum/issues/204)
#39 

## Tarefas gerais realizadas
- Fixado a largura do nome na Row para evitar Overflow
- Adição de parâmetro name obrigatório na página ProductorDetailsPage
- Criação de widget (Text) para quando o produtor não tiver nenhum anúncio cadastrado
- Adição de testes referentes ao serviço adicionado

## Teste
Para testar as alterações siga os passos:
1. Crie um produtor novo. Coloque nome e sobrenome.
2. Crie um consumidor
3. Acesse a página de detalhes por meio da visualização dos produtor cadastrados na HomeCustomerPage
4. Verifique se a página não está quebrando e a presença do aviso dizendo que o produtor não possui anúncios ainda.
5. Verifique o comportamento do nome do produtor na página.

