### PR TITLE
#224 Mudança visual Footer

### DIFF
--- a/hortum_mobile/lib/components/footer.dart
+++ b/hortum_mobile/lib/components/footer.dart
@@ -15,6 +15,23 @@ class Footer extends StatelessWidget {
           Align(
             alignment: Alignment.bottomCenter,
             child: Container(
+              height: size.height * 0.17,
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                    colors: [
+                      Colors.white.withOpacity(0.01),
+                      Colors.white,
+                    ],
+                    begin: AlignmentGeometry.lerp(
+                        Alignment.topCenter, Alignment.center, 0.2),
+                    end: AlignmentGeometry.lerp(
+                        Alignment.topCenter, Alignment.center, 0.8)),
+              ),
+            ),
+          ),
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: Container(
               decoration: BoxDecoration(
                 gradient: LinearGradient(colors: [
                   Color(0xff47CC70).withOpacity(0.7),

--- a/hortum_mobile/lib/views/productor_details/components/announcements_details.dart
+++ b/hortum_mobile/lib/views/productor_details/components/announcements_details.dart
@@ -19,7 +19,7 @@ class _AnnouncementsDetailsState extends State<AnnouncementsDetails> {
     Size size = MediaQuery.of(context).size;
     return Container(
         width: size.width,
-        height: size.height * 0.47,
+        height: size.height * 0.5,
         child: ListView(
           children: [
             Column(


### PR DESCRIPTION
## Descrição
Foi acrescentado ao footer um efeito para melhorar a visualização da página

## Está concertando alguma issue aberta?
[#224](https://github.com/fga-eps-mds/2020.2-Hortum/issues/224)

## Tarefas gerais realizadas
- Mudança do footer para acrescentar o efeito
- Mudança da página AnnouncementDetailsPage que estava acima de onde começa o footer

##Testes
Para testar basta entrar em alguma página que tenha scroll e contenha o footer. Os elementos que estiverem perto do footer devem perder a sua cor gradativamente. Além disso todas as páginas que contém scroll e footer devem estar sem espaços brancos antes do início do footer.
