### PR TITLE
#219 Deixar anúncio invisível

### DIFF
--- a/hortum_mobile/lib/data/announcements/announcements_backend.dart
+++ b/hortum_mobile/lib/data/announcements/announcements_backend.dart
@@ -102,14 +102,16 @@ class AnnouncementsApi {
       "Content-Type": "application/json",
       "Authorization": "Bearer " + actualUser.tokenAccess,
     };
+    String localizacao = null;
 
-    List<String> localizacao = [];
-
-    int index = 0;
-    localizations.forEach((element) {
-      localizacao.insert(index, element.text);
-      index++;
-    });
+    if (localizations != null) {
+      List<String> localizacao = [];
+      int index = 0;
+      localizations.forEach((element) {
+        localizacao.insert(index, element.text);
+        index++;
+      });
+    }
 
     Map params = {
       "name": name,

--- a/hortum_mobile/lib/views/home_productor/components/buttons_row.dart
+++ b/hortum_mobile/lib/views/home_productor/components/buttons_row.dart
@@ -1,20 +1,28 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:hortum_mobile/data/announcements/announcements_backend.dart';
 import 'package:hortum_mobile/views/edit_announ/edit_page.dart';
 import 'package:hortum_mobile/views/home_productor/components/dialog_confirm_delete.dart';
 
+import '../home_productor_page.dart';
+
 class ButtonsRow extends StatefulWidget {
+  final Dio dio;
   final String title;
   final String description;
   final List localization;
   final String price;
   final String category;
+  final bool inventory;
 
   const ButtonsRow(
-      {@required this.title,
+      {this.dio,
+      @required this.title,
       @required this.description,
       @required this.price,
       @required this.localization,
       @required this.category,
+      @required this.inventory,
       Key key})
       : super(key: key);
 
@@ -24,7 +32,8 @@ class ButtonsRow extends StatefulWidget {
       description: description,
       price: price,
       localization: localization,
-      category: category);
+      category: category,
+      inventory: inventory);
 }
 
 class _ButtonRowState extends State<ButtonsRow> {
@@ -33,13 +42,15 @@ class _ButtonRowState extends State<ButtonsRow> {
   final List localization;
   final String price;
   final String category;
+  final bool inventory;
 
   _ButtonRowState(
       {this.title,
       this.description,
       this.localization,
       this.price,
-      this.category});
+      this.category,
+      this.inventory});
 
   @override
   Widget build(BuildContext context) {
@@ -58,6 +69,7 @@ class _ButtonRowState extends State<ButtonsRow> {
     final TextEditingController category =
         TextEditingController(text: widget.category);
     Size size = MediaQuery.of(context).size;
+    AnnouncementsApi announcementsApi = new AnnouncementsApi();
 
     return Container(
       color: Color(0xFFECF87F).withOpacity(0.4),
@@ -96,12 +108,24 @@ class _ButtonRowState extends State<ButtonsRow> {
             width: size.width * 0.06,
             child: MaterialButton(
               padding: EdgeInsets.all(0),
-              child: Icon(
-                Icons.visibility_off,
-                size: 25,
-                color: Color(0xFF478C5C),
-              ),
-              onPressed: () {},
+              child: inventory
+                  ? Icon(
+                      Icons.visibility,
+                      size: 25,
+                      color: Color(0xFF478C5C),
+                    )
+                  : Icon(
+                      Icons.visibility_off,
+                      size: 25,
+                      color: Color(0xFF478C5C),
+                    ),
+              onPressed: () async {
+                await announcementsApi.editAnnoun(title.text,
+                    inventory: !inventory);
+                Navigator.push(context, MaterialPageRoute(builder: (context) {
+                  return ProductorHomePage(dio: widget.dio);
+                }));
+              },
             ),
           ),
           Container(

--- a/hortum_mobile/lib/views/home_productor/components/list_announcements.dart
+++ b/hortum_mobile/lib/views/home_productor/components/list_announcements.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:hortum_mobile/components/announcement_box.dart';
 import 'package:hortum_mobile/views/home_productor/components/buttons_row.dart';
@@ -5,8 +6,9 @@ import 'package:hortum_mobile/data/prod_log_data_backend.dart';
 
 class ListAnnouncement extends StatefulWidget {
   final ProdLoggedAnnounDataApi announProd;
+  final Dio dio;
 
-  const ListAnnouncement({@required this.announProd, Key key})
+  const ListAnnouncement({@required this.announProd, this.dio, Key key})
       : super(key: key);
 
   @override
@@ -30,11 +32,14 @@ class _ListAnnouncementState extends State<ListAnnouncement> {
                 itemBuilder: (context, index) {
                   return Column(children: [
                     ButtonsRow(
-                        title: announcements[index]['name'],
-                        localization: announcements[index]['localizations'],
-                        price: announcements[index]['price'],
-                        description: announcements[index]['description'],
-                        category: announcements[index]['type_of_product']),
+                      dio: widget.dio,
+                      title: announcements[index]['name'],
+                      localization: announcements[index]['localizations'],
+                      price: announcements[index]['price'],
+                      description: announcements[index]['description'],
+                      category: announcements[index]['type_of_product'],
+                      inventory: announcements[index]['inventory'],
+                    ),
                     AnnouncementBox(
                         description: announcements[index]['description'],
                         profilePic: 'assets/images/perfil.jpg',

--- a/hortum_mobile/lib/views/home_productor/home_productor_page.dart
+++ b/hortum_mobile/lib/views/home_productor/home_productor_page.dart
@@ -45,6 +45,7 @@ class _ProductorHomePageState extends State<ProductorHomePage> {
                             height: size.height * 0.75,
                             margin: EdgeInsets.only(bottom: size.height * 0.05),
                             child: ListAnnouncement(
+                              dio: widget.dio,
                               announProd: announProd,
                             ))
                         : Container(

--- a/hortum_mobile/test/views/home_productor/home_productor_page_test.dart
+++ b/hortum_mobile/test/views/home_productor/home_productor_page_test.dart
@@ -22,7 +22,8 @@ main() {
       "price": 5.0,
       "idPicture": null,
       "likes": 0,
-      "localizations": ["Lugar", "Outro lugar"]
+      "localizations": ["Lugar", "Outro lugar"],
+      "inventory": true,
     },
   ];
 
@@ -94,6 +95,64 @@ main() {
         await tester.pumpAndSettle();
 
         expect(find.byKey(Key('salvarAnnoun')), findsOneWidget);
+      });
+
+      testWidgets(
+          'Testing change inventory when clicking visibility_off button',
+          (WidgetTester tester) async {
+        actualUser.isProductor = true;
+        actualUser.tokenAccess = 'token';
+        actualUser.email = 'productor@email.com';
+        List<dynamic> responseInventoryFalse = [
+          {
+            "email": "usuário@gmail.com",
+            "username": "Usuário Teste",
+            "idPictureProductor": null,
+            "name": "Folha Verde",
+            "type_of_product": "Alface",
+            "description": "Alface plantado na fazenda",
+            "price": 5.0,
+            "idPicture": null,
+            "likes": 0,
+            "localizations": ["Lugar", "Outro lugar"],
+            "inventory": false,
+          },
+        ];
+        when(dioMock.patch(any,
+                data: anyNamed('data'), options: anyNamed('options')))
+            .thenAnswer((_) async =>
+                Response(data: '', requestOptions: null, statusCode: 200));
+
+        when(dioMock.get(any, options: anyNamed('options'))).thenAnswer(
+            (_) async =>
+                Response(data: responseInventoryFalse, requestOptions: null));
+
+        await tester.pumpWidget(makeTestable());
+        await tester.pump();
+        expect(find.byIcon(Icons.visibility_off), findsOneWidget);
+        await tester.tap(find.byIcon(Icons.visibility_off).first);
+        await tester.pumpAndSettle();
+      });
+
+      testWidgets('Testing change inventory when clicking visibility button',
+          (WidgetTester tester) async {
+        actualUser.isProductor = true;
+        actualUser.tokenAccess = 'token';
+        actualUser.email = 'productor@email.com';
+
+        when(dioMock.get(any, options: anyNamed('options'))).thenAnswer(
+            (_) async => Response(data: response, requestOptions: null));
+
+        when(dioMock.patch(any,
+                data: anyNamed('data'), options: anyNamed('options')))
+            .thenAnswer((_) async =>
+                Response(data: '', requestOptions: null, statusCode: 200));
+
+        await tester.pumpWidget(makeTestable());
+        await tester.pump();
+        expect(find.byIcon(Icons.visibility), findsOneWidget);
+        await tester.tap(find.byIcon(Icons.visibility).first);
+        await tester.pumpAndSettle();
       });
     });
   });


### PR DESCRIPTION
## Descrição
- Funcionalidade de alterar a visibilidade de um anúncio.

## Está consertando alguma issue aberta?
- [#219](https://github.com/fga-eps-mds/2020.2-Hortum/issues/219)

## Tarefas gerais realizadas
- Adicionada funcionalidade do botão de visibilidade de anúncios
- Adicionado testes do botão de visiblidade de anúncios
